### PR TITLE
Provide sensible .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Cloud9 IDE
+.c9/
+
+# Robomaker build artifacts and log directories
+
+simulation_ws/build/
+simulation_ws/bundle/
+simulation_ws/install/
+simulation_ws/log/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .c9/
 
 # Robomaker build artifacts and log directories
+roboMakerLogs/
 simulation_ws/build/
 simulation_ws/bundle/
 simulation_ws/install/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .c9/
 
 # Robomaker build artifacts and log directories
-
 simulation_ws/build/
 simulation_ws/bundle/
 simulation_ws/install/


### PR DESCRIPTION
Importing and building/bundling provided code from within Cloud9 results in a number of artifacts/logs that shouldn't be contributed back.