### PR TITLE
missing coma in settings file

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -26,7 +26,7 @@
         "simulation": {
           "maxJobDurationInSeconds": 300,
           "failureBehavior": "Continue",
-          "iamRole": "[YOUR IAM ROLE]"
+          "iamRole": "[YOUR IAM ROLE]",
           "outputLocation": "burnsca-training",
           "tags": {}
         },


### PR DESCRIPTION
## Description
The default settings json file is missing a coma which makes it invalid json.

## Changelog:
- add coma