### PR TITLE
Changing Discrete Variables to Continuous Variables for More Algorithms

### DIFF
--- a/simulation_ws/src/rl-agent/markov/environments/mars_env.py
+++ b/simulation_ws/src/rl-agent/markov/environments/mars_env.py
@@ -597,22 +597,26 @@ class MarsDiscreteEnv(MarsEnv):
         print("New Martian Gym environment created...")
         
         # actions -> straight, left, right
-        self.action_space = spaces.Discrete(3)
+        ## Commenting out to enable continuous space algorithms
+        # self.action_space = spaces.Discrete(3)
 
     def step(self, action):
         # Convert discrete to continuous
-        if action == 0:  # turn left
-            steering = 1.0
-            throttle = 3.00
-        elif action == 1:  # turn right
-            steering = -1.0
-            throttle = 3.00
-        elif action == 2:  # straight
-            steering = 0
-            throttle = 3.00
-        else:  # should not be here
-            raise ValueError("Invalid action")
+        ##Keeping continuous space intact
+        # if action == 0:  # turn left
+        #     steering = 1.0
+        #     throttle = 3.00
+        # elif action == 1:  # turn right
+        #     steering = -1.0
+        #     throttle = 3.00
+        # elif action == 2:  # straight
+        #     steering = 0
+        #     throttle = 3.00
+        # else:  # should not be here
+        #     raise ValueError("Invalid action")
+        #
+        # continuous_action = [steering, throttle]
+        #
+        # return super().step(continuous_action)
 
-        continuous_action = [steering, throttle]
-
-        return super().step(continuous_action)
+        return super().step(action)

--- a/simulation_ws/src/rl-agent/setup.py
+++ b/simulation_ws/src/rl-agent/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
        'boto3==1.9.23',
         'futures==3.1.1',
-        'gym==0.10.5',
+        'gym',
         'kubernetes==7.0.0',
         'minio==4.0.5',
         'numpy==1.14.5',
@@ -23,7 +23,7 @@ setup(
         'rospkg==1.1.7',
         'scipy==0.19.0',
         'tensorflow==1.12.2',
-        'rl-coach-slim==0.11.1',
+        'rl-coach-slim',
     ],
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
I changed the the `MarsDiscreteEnv(MarsEnv)` to produce continuous actions instead of the `self.action_space = spaces.Discrete(3)` which signals that the action space is discrete to the RL manager and thereby limits the implementation of continuous based RL algorithms. I have also added comments in my changes.

In the `setup.py` file of the `rl-agent` repo I changed the install to have newer version of `gym` and `rl-coach` to have access to a larger library of RL algorithms from RL coach.